### PR TITLE
Replacing the function get_macd() with get_macdext() as macd is a Premium command

### DIFF
--- a/src/full_financial_plot.py
+++ b/src/full_financial_plot.py
@@ -29,7 +29,7 @@ class Plot:
         data_daily, meta_data_ts = self.ts.get_daily(ticker,
                                                      outputsize='full')  # pylint: disable=unbalanced-tuple-unpacking
         sar_daily, meta_sar = self.ti.get_sar(ticker, interval=interval)  # pylint: disable=unbalanced-tuple-unpacking
-        macd_daily, meta_macd = self.ti.get_macd(ticker, interval=interval,
+        macd_daily, meta_macd = self.ti.get_macdext(ticker, interval=interval,
                                                  series_type=series_type)  # pylint: disable=unbalanced-tuple-unpacking
         ema_daily8, meta_ema = self.ti.get_ema(ticker, interval=interval, time_period=first_ema_period,
                                                series_type=series_type)  # pylint: disable=unbalanced-tuple-unpacking


### PR DESCRIPTION
    Replacing the function get_macd() with get_macdext() as macd is a Premium command and
    needs Premium Endppint access while a comparable command MACDEXT doesn't need
    Premium access and serves the same purpose and and can be used by anyone.

Reference:
    MACD
    https://www.alphavantage.co/documentation/#macd
    MACDEXT
    https://www.alphavantage.co/documentation/#macdext

This is the output after running the command

<img width="1517" alt="image" src="https://github.com/suha-memon/Plotly-Financial-Data-Visualization/assets/10245431/d5d0daba-3bf5-40e1-8107-01d884439794">
